### PR TITLE
Preserve view owners after post-finalize and post-revert

### DIFF
--- a/data-migration-scripts/create_find_view_dep_function.sql
+++ b/data-migration-scripts/create_find_view_dep_function.sql
@@ -17,9 +17,9 @@ import plpy
 # First find views that do not depend on other views (and directly on the table)
 
 leaf_view = plpy.execute("""
-SELECT schema, view
+SELECT schema, view, owner
 FROM (
-SELECT DISTINCT nv.nspname AS schema, v.relname AS view
+SELECT DISTINCT nv.nspname AS schema, v.relname AS view, pg_catalog.pg_get_userbyid(v.relowner) AS owner
 FROM pg_depend d
     JOIN pg_rewrite r ON r.oid = d.objid
     JOIN pg_class v ON v.oid = r.ev_class
@@ -50,14 +50,16 @@ WHERE
 checklist = {}
 view_order = 1
 for row in leaf_view:
-    checklist[(row['schema'], row['view'])] = view_order
+    checklist[(row['schema'], row['view'], row['owner'])] = view_order
 
 rows = plpy.execute("""
     SELECT
         nsp1.nspname AS depender_schema,
         depender,
+        depender_owner,
         nsp2.nspname AS dependee_schema,
-        dependee
+        dependee,
+        dependee_owner
     FROM
         pg_namespace AS nsp1,
         pg_namespace AS nsp2,
@@ -65,8 +67,10 @@ rows = plpy.execute("""
             SELECT
                 c.relname depender,
                 c.relnamespace AS depender_nsp,
+                pg_catalog.pg_get_userbyid(c.relowner) as depender_owner,
                 c1.relname AS dependee,
-                c1.relnamespace AS dependee_nsp
+                c1.relnamespace AS dependee_nsp,
+                pg_catalog.pg_get_userbyid(c1.relowner) as dependee_owner
             FROM
                 pg_rewrite AS rw,
                 pg_depend AS d,
@@ -81,7 +85,7 @@ rows = plpy.execute("""
                 c1.relkind = 'v' AND
                 c.relname <> c1.relname
             GROUP BY
-                depender, depender_nsp, dependee, dependee_nsp
+                depender, depender_nsp, depender_owner, dependee, dependee_nsp, dependee_owner
         ) t1
     WHERE
         t1.depender_nsp = nsp1.oid AND
@@ -98,8 +102,8 @@ rows = plpy.execute("""
 
 view2view = {}
 for row in rows:
-    key = (row['depender_schema'], row['depender'])
-    val = (row['dependee_schema'], row['dependee'])
+    key = (row['depender_schema'], row['depender'], row['depender_owner'])
+    val = (row['dependee_schema'], row['dependee'], row['dependee_owner'])
     view2view[key]=val
 
 while True:
@@ -114,9 +118,9 @@ while True:
         checklist.update(new_checklist)
 
 plpy.execute("DROP TABLE IF EXISTS  __gpupgrade_tmp_generator.__temp_views_list")
-plpy.execute("CREATE TABLE  __gpupgrade_tmp_generator.__temp_views_list (full_view_name TEXT, view_order INTEGER)")
+plpy.execute("CREATE TABLE  __gpupgrade_tmp_generator.__temp_views_list (full_view_name TEXT, view_owner TEXT, view_order INTEGER)")
 for v, view_order in checklist.items():
-    sql = "INSERT INTO  __gpupgrade_tmp_generator.__temp_views_list VALUES('{0}.{1}', {2})".format(v[0],v[1],view_order)
+    sql = "INSERT INTO  __gpupgrade_tmp_generator.__temp_views_list VALUES('{0}.{1}', '{2}', {3})".format(v[0],v[1],v[2],view_order)
     plpy.execute(sql)
 $$ LANGUAGE plpythonu;
 

--- a/data-migration-scripts/post-finalize/recreate_views_on_deprecated_built_in_types.sql
+++ b/data-migration-scripts/post-finalize/recreate_views_on_deprecated_built_in_types.sql
@@ -1,6 +1,7 @@
 -- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
 -- SPDX-License-Identifier: Apache-2.0
 
-SELECT $$CREATE VIEW $$|| full_view_name || $$ AS $$ ||
-    pg_catalog.pg_get_viewdef(full_view_name::regclass::oid, false) || $$;$$
+SELECT
+    $$CREATE VIEW $$|| full_view_name || $$ AS $$ || pg_catalog.pg_get_viewdef(full_view_name::regclass::oid, false) || $$;$$ || E'\n'||
+    $$ALTER VIEW $$|| full_view_name || $$ OWNER TO $$ || view_owner || $$;$$
 FROM __gpupgrade_tmp_generator.__temp_views_list ORDER BY view_order;

--- a/data-migration-scripts/post-revert/recreate_views_on_deprecated_built_in_types.sql
+++ b/data-migration-scripts/post-revert/recreate_views_on_deprecated_built_in_types.sql
@@ -1,6 +1,7 @@
 -- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
 -- SPDX-License-Identifier: Apache-2.0
 
-SELECT $$CREATE VIEW $$|| full_view_name || $$ AS $$ ||
-    pg_catalog.pg_get_viewdef(full_view_name::regclass::oid, false) || $$;$$
+SELECT
+    $$CREATE VIEW $$|| full_view_name || $$ AS $$ || pg_catalog.pg_get_viewdef(full_view_name::regclass::oid, false) || $$;$$ || E'\n'||
+    $$ALTER TABLE $$|| full_view_name || $$ OWNER TO $$ || view_owner || $$;$$
 FROM __gpupgrade_tmp_generator.__temp_views_list ORDER BY view_order;

--- a/data-migration-scripts/test/create_nonupgradable_objects.sql
+++ b/data-migration-scripts/test/create_nonupgradable_objects.sql
@@ -72,9 +72,6 @@ ALTER TABLE table_with_primary_constraint ADD UNIQUE (author, title);
 INSERT INTO table_with_primary_constraint VALUES(1, 1);
 INSERT INTO table_with_primary_constraint VALUES(2, 2);
 
--- create role with gphdfs readable and writable privileges
-CREATE ROLE gphdfs_user CREATEEXTTABLE(protocol='gphdfs', type='writable') CREATEEXTTABLE(protocol='gphdfs', type='readable');
-
 -- create partitioned tables where the index relation name is not equal primary/unique key constraint name for the root
 -- Note that the naming of the constraint is key, not the type of constraint
 -- If the constraint is named, every partition will have the same named constraint and they all can be dropped with the same command
@@ -267,11 +264,12 @@ CREATE UNIQUE INDEX ml_partitioned_with_index_idx ON ml_partitioned_with_index(t
 
 -- Heterogeneous partition table with dropped column
 -- The root and only a subset of children have the dropped column reference.
-CREATE TABLE dropped_column (a int, b int, c char, d varchar(50)) DISTRIBUTED BY (c)
+CREATE TABLE dropped_column (a int CONSTRAINT positive_int CHECK (b > 0), b int DEFAULT 1, c char, d varchar(50)) DISTRIBUTED BY (c)
     PARTITION BY RANGE (a)
         (PARTITION part_1 START(1) END(5),
         PARTITION part_2 START(5));
 ALTER TABLE dropped_column DROP COLUMN d;
+ALTER TABLE dropped_column OWNER TO testrole;
 
 -- Splitting the subpartition leads to its rewrite, eliminating its dropped column
 -- reference. So, after this, only part_2 and the root partition will have a

--- a/data-migration-scripts/test/create_nonupgradable_objects.sql
+++ b/data-migration-scripts/test/create_nonupgradable_objects.sql
@@ -120,7 +120,7 @@ CREATE TABLE partition_table_partitioned_by_name_type(a int, b name) PARTITION B
 DROP TABLE IF EXISTS table_distributed_by_name_type;
 CREATE TABLE table_distributed_by_name_type(a int, b name) DISTRIBUTED BY (b);
 INSERT INTO table_distributed_by_name_type VALUES (1,'z'),(2,'x');
--- create table / views with name dataype
+-- create table / views with name datatype
 CREATE TABLE t1_with_name(a name, b name) DISTRIBUTED RANDOMLY;
 INSERT INTO t1_with_name SELECT 'aaa', 'bbb';
 CREATE TABLE t2_with_name(a int, b name) DISTRIBUTED RANDOMLY;
@@ -205,9 +205,10 @@ CREATE TABLE name_inherits (
     state      char(2)
 ) INHERITS (table_with_name_tsquery);
 
--- view on a view on a name column
+-- view on a view on a name column with owner different than the underlying table
 DROP VIEW IF EXISTS v3_on_v2_recursive;
 CREATE VIEW v3_on_v2_recursive AS SELECT * FROM v2_on_t2_with_name;
+ALTER TABLE v3_on_v2_recursive OWNER TO test_role;
 
 -- Third level recursive view on a name column
 DROP VIEW IF EXISTS v4_on_v3_recursive;

--- a/data-migration-scripts/test/setup_nonupgradable_objects.sql
+++ b/data-migration-scripts/test/setup_nonupgradable_objects.sql
@@ -1,0 +1,7 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- CREATE global objects
+CREATE DATABASE testdb;
+CREATE ROLE gphdfs_user CREATEEXTTABLE(protocol='gphdfs', type='writable') CREATEEXTTABLE(protocol='gphdfs', type='readable');
+CREATE ROLE test_role;

--- a/data-migration-scripts/test/teardown_nonupgradable_objects.sql
+++ b/data-migration-scripts/test/teardown_nonupgradable_objects.sql
@@ -1,0 +1,7 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- DROP global objects
+DROP DATABASE IF EXISTS testdb;
+DROP ROLE IF EXISTS gphdfs_user;
+DROP ROLE IF EXISTS test_role;

--- a/test/acceptance/gpupgrade/migration_scripts.bats
+++ b/test/acceptance/gpupgrade/migration_scripts.bats
@@ -20,11 +20,11 @@ setup() {
 
     PSQL="$GPHOME_SOURCE/bin/psql -X --no-align --tuples-only"
 
-    $PSQL -f "$SCRIPTS_DIR"/test/setup_nonupgradable_objects.sql -d postgres
+    $PSQL -d postgres -f "$SCRIPTS_DIR"/test/setup_nonupgradable_objects.sql
 }
 
 teardown() {
-    $PSQL -f "$SCRIPTS_DIR"/test/teardown_nonupgradable_objects.sql -d postgres
+    $PSQL -d postgres -f "$SCRIPTS_DIR"/test/teardown_nonupgradable_objects.sql
 
     # XXX Beware, BATS_TEST_SKIPPED is not a documented export.
     if [ -n "${BATS_TEST_SKIPPED}" ]; then
@@ -37,7 +37,7 @@ teardown() {
 }
 
 @test "migration scripts generate sql to modify non-upgradeable objects and fix pg_upgrade check errors" {
-    PGOPTIONS='--client-min-messages=warning' $PSQL -f "$SCRIPTS_DIR"/test/create_nonupgradable_objects.sql -d testdb
+    PGOPTIONS='--client-min-messages=warning' $PSQL -d testdb -f "$SCRIPTS_DIR"/test/create_nonupgradable_objects.sql
     run gpupgrade initialize \
         --source-gphome="$GPHOME_SOURCE" \
         --target-gphome="$GPHOME_TARGET" \
@@ -105,7 +105,7 @@ teardown() {
 }
 
 @test "after reverting recreate scripts must restore non-upgradeable objects" {
-    $PSQL -f "$SCRIPTS_DIR"/test/create_nonupgradable_objects.sql -d testdb
+    $PSQL -d testdb -f "$SCRIPTS_DIR"/test/create_nonupgradable_objects.sql
     $PSQL -d testdb -f "$SCRIPTS_DIR"/test/drop_unfixable_objects.sql
 
     root_child_indexes_before=$(get_indexes "$GPHOME_SOURCE")
@@ -158,7 +158,7 @@ teardown() {
         skip "GPDB 5 does not support alternative PSQLRC locations"
     fi
 
-    $PSQL -f "$SCRIPTS_DIR"/test/create_nonupgradable_objects.sql -d testdb
+    $PSQL -d testdb -f "$SCRIPTS_DIR"/test/create_nonupgradable_objects.sql
 
     MIGRATION_DIR=$(mktemp -d /tmp/migration.XXXXXX)
     register_teardown rm -r "$MIGRATION_DIR"

--- a/test/acceptance/gpupgrade/migration_scripts.bats
+++ b/test/acceptance/gpupgrade/migration_scripts.bats
@@ -62,6 +62,7 @@ teardown() {
     partition_owners_before=$(get_partition_owners "$GPHOME_SOURCE")
     partition_constraints_before=$(get_partition_constraints "$GPHOME_SOURCE")
     partition_defaults_before=$(get_partition_defaults "$GPHOME_SOURCE")
+    view_owners_before=$(get_view_owners "$GPHOME_SOURCE")
 
     MIGRATION_DIR=`mktemp -d /tmp/migration.XXXXXX`
     "$SCRIPTS_DIR"/gpupgrade-migration-sql-generator.bash "$GPHOME_SOURCE" "$PGPORT" "$MIGRATION_DIR" "$SCRIPTS_DIR"
@@ -92,6 +93,7 @@ teardown() {
     partition_owners_after=$(get_partition_owners "$GPHOME_TARGET")
     partition_constraints_after=$(get_partition_constraints "$GPHOME_TARGET")
     partition_defaults_after=$(get_partition_defaults "$GPHOME_TARGET")
+    view_owners_after=$(get_view_owners "$GPHOME_TARGET")
 
     # expect the index and tsquery datatype information to be same after the upgrade
     diff -U3 <(echo "$root_child_indexes_before") <(echo "$root_child_indexes_after")
@@ -102,6 +104,7 @@ teardown() {
     diff -U3 <(echo "$partition_owners_before") <(echo "$partition_owners_after")
     diff -U3 <(echo "$partition_constraints_before") <(echo "$partition_constraints_after")
     diff -U3 <(echo "$partition_defaults_before") <(echo "$partition_defaults_after")
+    diff -U3 <(echo "$view_owners_before") <(echo "$view_owners_after")
 }
 
 @test "after reverting recreate scripts must restore non-upgradeable objects" {
@@ -113,6 +116,7 @@ teardown() {
     name_datatype_objects_before=$(get_name_datatypes "$GPHOME_SOURCE")
     fk_constraints_before=$(get_fk_constraints "$GPHOME_SOURCE")
     primary_unique_constraints_before=$(get_primary_unique_constraints "$GPHOME_SOURCE")
+    view_owners_before=$(get_view_owners "$GPHOME_SOURCE")
 
     # Ignore the test tables that break the diff for now.
     EXCLUSIONS+="-T testschema.heterogeneous_ml_partition_table "
@@ -142,6 +146,7 @@ teardown() {
     name_datatype_objects_after=$(get_name_datatypes "$GPHOME_SOURCE")
     fk_constraints_after=$(get_fk_constraints "$GPHOME_SOURCE")
     primary_unique_constraints_after=$(get_primary_unique_constraints "$GPHOME_SOURCE")
+    view_owners_after=$(get_view_owners "$GPHOME_TARGET")
 
     # expect the index and tsquery datatype information to be same after the upgrade
     diff -U3 <(echo "$root_child_indexes_before") <(echo "$root_child_indexes_after")
@@ -149,6 +154,7 @@ teardown() {
     diff -U3 <(echo "$name_datatype_objects_before") <(echo "$name_datatype_objects_after")
     diff -U3 <(echo "$fk_constraints_before") <(echo "$fk_constraints_after")
     diff -U3 <(echo "$primary_unique_constraints_before") <(echo "$primary_unique_constraints_after")
+    diff -U3 <(echo "$view_owners_before") <(echo "$view_owners_after")
 }
 
 @test "migration scripts ignore .psqlrc files" {
@@ -375,3 +381,19 @@ get_partition_defaults() {
     "
 }
 
+get_view_owners() {
+    local gphome=$1
+    $gphome/bin/psql -d testdb -p "$PGPORT" -Atc "
+    SELECT n.nspname as "Schema",
+        c.relname as "Name",
+        CASE c.relkind WHEN 'r' THEN 'table' WHEN 'v' THEN 'view' WHEN 'i' THEN 'index' WHEN 'S' THEN 'sequence' WHEN 's' THEN 'special' END as "Type",
+        pg_catalog.pg_get_userbyid(c.relowner) as "Owner", CASE c.relstorage WHEN 'h' THEN 'heap' WHEN 'x' THEN 'external' WHEN 'a' THEN 'append only' WHEN 'v' THEN 'none' WHEN 'c' THEN 'append only columnar' END as "Storage"
+    FROM pg_catalog.pg_class c
+        LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind IN ('v','s','')
+        AND c.relstorage IN ('v','')
+        AND n.nspname !~ '^pg_toast'
+        AND n.nspname ~ '^(testschema)$'
+    ORDER BY 1,2;
+    "
+}

--- a/test/acceptance/helpers/helpers.bash
+++ b/test/acceptance/helpers/helpers.bash
@@ -353,13 +353,14 @@ backup_source_cluster() {
     local datadir_root
     datadir_root="$(realpath "$MASTER_DATA_DIRECTORY"/../..)"
 
-    gpstop -af
-    register_teardown gpstart -a
+    (source "$GPHOME_SOURCE"/greenplum_path.sh && "$GPHOME_SOURCE"/bin/gpstop -af)
+    register_teardown start_source_cluster
+
 
     rsync --archive "${datadir_root:?}"/ "${backup_dir:?}"/
     register_teardown rsync --archive -I --delete "${backup_dir:?}"/ "${datadir_root:?}"/
 
-    gpstart -a
+    (source "$GPHOME_SOURCE"/greenplum_path.sh && "$GPHOME_SOURCE"/bin/gpstart -a)
     register_teardown stop_any_cluster
 }
 


### PR DESCRIPTION
As part of gpupgrade views are manually recreated by us. This change
ensures the owners of the views are preserved after post-revert or
post-finalize is run.

pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:migration-script-view-owner