### PR TITLE
pg_upgrade nonupgradable test detecting views with removed functions

### DIFF
--- a/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/expected/views_with_removed_functions.out
+++ b/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/expected/views_with_removed_functions.out
@@ -1,0 +1,94 @@
+-- Copyright (c) 2017-2024 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Create and setup non-upgradeable objects
+--------------------------------------------------------------------------------
+
+CREATE TABLE foo(i int) with (appendonly=true);
+CREATE TABLE
+CREATE TABLE rank_table (id int, rank int, year int, gender char(1), count int ) DISTRIBUTED BY (id) PARTITION BY LIST (gender) ( PARTITION girls VALUES ('F'), PARTITION boys VALUES ('M'), DEFAULT PARTITION other );
+CREATE TABLE
+
+CREATE VIEW v01 AS SELECT pg_catalog.pg_current_xlog_insert_location();
+CREATE VIEW
+CREATE VIEW v02 AS SELECT pg_catalog.pg_current_xlog_location();
+CREATE VIEW
+CREATE VIEW v03 AS SELECT pg_catalog.gp_update_ao_master_stats('public.foo'::regclass);
+CREATE VIEW
+CREATE VIEW v04 AS SELECT pg_get_partition_def('rank_table'::regclass);
+CREATE VIEW
+CREATE VIEW v05 AS SELECT pg_get_partition_def('rank_table'::regclass, true);
+CREATE VIEW
+CREATE VIEW v06 AS SELECT pg_get_partition_def('rank_table'::regclass, true, true);
+CREATE VIEW
+CREATE VIEW v07 AS SELECT pg_get_partition_rule_def('rank_table'::regclass);
+CREATE VIEW
+CREATE VIEW v08 AS SELECT pg_get_partition_rule_def('rank_table'::regclass, true);
+CREATE VIEW
+CREATE VIEW v09 AS SELECT pg_get_partition_template_def('rank_table'::regclass, true, true);
+CREATE VIEW
+CREATE VIEW v10 AS SELECT pg_catalog.pg_is_xlog_replay_paused();
+CREATE VIEW
+CREATE VIEW v11 AS SELECT pg_catalog.pg_last_xlog_receive_location();
+CREATE VIEW
+CREATE VIEW v12 AS SELECT pg_catalog.pg_last_xlog_replay_location();
+CREATE VIEW
+CREATE VIEW v13 AS SELECT pg_catalog.pg_switch_xlog();
+CREATE VIEW
+
+---------------------------------------------------------------------------------
+--- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
+---------------------------------------------------------------------------------
+!\retcode gpupgrade initialize --source-gphome="${GPHOME_SOURCE}" --target-gphome=${GPHOME_TARGET} --source-master-port=${PGPORT} --disk-free-ratio 0 --non-interactive;
+(exited with code 1)
+! cat ~/gpAdminLogs/gpupgrade/pg_upgrade/p-1/views_with_removed_functions.txt;
+Database: isolation2test
+  public.v01
+  public.v02
+  public.v03
+  public.v04
+  public.v05
+  public.v06
+  public.v07
+  public.v08
+  public.v09
+  public.v10
+  public.v11
+  public.v12
+  public.v13
+
+
+---------------------------------------------------------------------------------
+--- Workaround to unblock upgrade
+---------------------------------------------------------------------------------
+DROP VIEW v13;
+DROP VIEW
+DROP VIEW v12;
+DROP VIEW
+DROP VIEW v11;
+DROP VIEW
+DROP VIEW v10;
+DROP VIEW
+DROP VIEW v09;
+DROP VIEW
+DROP VIEW v08;
+DROP VIEW
+DROP VIEW v07;
+DROP VIEW
+DROP VIEW v06;
+DROP VIEW
+DROP VIEW v05;
+DROP VIEW
+DROP VIEW v04;
+DROP VIEW
+DROP VIEW v03;
+DROP VIEW
+DROP VIEW v02;
+DROP VIEW
+DROP VIEW v01;
+DROP VIEW
+DROP TABLE rank_table;
+DROP TABLE
+DROP TABLE foo;
+DROP TABLE

--- a/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/non_upgradeable_schedule
+++ b/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/non_upgradeable_schedule
@@ -4,3 +4,4 @@ test: reg_data_types
 test: sql_identifier_types
 test: unknown_types
 test: views_with_removed_operators
+test: views_with_removed_functions

--- a/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/sql/views_with_removed_functions.sql
+++ b/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/sql/views_with_removed_functions.sql
@@ -1,0 +1,54 @@
+-- Copyright (c) 2017-2024 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Create and setup non-upgradeable objects
+--------------------------------------------------------------------------------
+
+CREATE TABLE foo(i int) with (appendonly=true);
+CREATE TABLE rank_table (id int, rank int, year int, gender
+char(1), count int )
+DISTRIBUTED BY (id)
+PARTITION BY LIST (gender)
+( PARTITION girls VALUES ('F'),
+  PARTITION boys VALUES ('M'),
+  DEFAULT PARTITION other );
+
+CREATE VIEW v01 AS SELECT pg_catalog.pg_current_xlog_insert_location();
+CREATE VIEW v02 AS SELECT pg_catalog.pg_current_xlog_location();
+CREATE VIEW v03 AS SELECT pg_catalog.gp_update_ao_master_stats('public.foo'::regclass);
+CREATE VIEW v04 AS SELECT pg_get_partition_def('rank_table'::regclass);
+CREATE VIEW v05 AS SELECT pg_get_partition_def('rank_table'::regclass, true);
+CREATE VIEW v06 AS SELECT pg_get_partition_def('rank_table'::regclass, true, true);
+CREATE VIEW v07 AS SELECT pg_get_partition_rule_def('rank_table'::regclass);
+CREATE VIEW v08 AS SELECT pg_get_partition_rule_def('rank_table'::regclass, true);
+CREATE VIEW v09 AS SELECT pg_get_partition_template_def('rank_table'::regclass, true, true);
+CREATE VIEW v10 AS SELECT pg_catalog.pg_is_xlog_replay_paused();
+CREATE VIEW v11 AS SELECT pg_catalog.pg_last_xlog_receive_location();
+CREATE VIEW v12 AS SELECT pg_catalog.pg_last_xlog_replay_location();
+CREATE VIEW v13 AS SELECT pg_catalog.pg_switch_xlog();
+
+---------------------------------------------------------------------------------
+--- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
+---------------------------------------------------------------------------------
+!\retcode gpupgrade initialize --source-gphome="${GPHOME_SOURCE}" --target-gphome=${GPHOME_TARGET} --source-master-port=${PGPORT} --disk-free-ratio 0 --non-interactive;
+! cat ~/gpAdminLogs/gpupgrade/pg_upgrade/p-1/views_with_removed_functions.txt;
+
+---------------------------------------------------------------------------------
+--- Workaround to unblock upgrade
+---------------------------------------------------------------------------------
+DROP VIEW v13;
+DROP VIEW v12;
+DROP VIEW v11;
+DROP VIEW v10;
+DROP VIEW v09;
+DROP VIEW v08;
+DROP VIEW v07;
+DROP VIEW v06;
+DROP VIEW v05;
+DROP VIEW v04;
+DROP VIEW v03;
+DROP VIEW v02;
+DROP VIEW v01;
+DROP TABLE rank_table;
+DROP TABLE foo;


### PR DESCRIPTION
Views that use removed functions will cause upgrade to fail. This happens during metadata restore on the target cluster because pg_restore will error trying to create a view using functions that do not exist anymore. This is not ideal as we could be many hours into upgrade before a view using a removed function causes pg_upgrade to fail. This check calls a support function on the source cluster to check if views using removed functions exist.


sister PRs:
https://github.com/kyeap-vmware/gpupgrade/pull/3
https://github.com/kyeap-vmware/gpdb/pull/3
https://github.com/kyeap-vmware/gpdb/pull/4
